### PR TITLE
fixed args.state issues for dr 3.x

### DIFF
--- a/app/main.rb
+++ b/app/main.rb
@@ -189,8 +189,9 @@ def setup(args)
   KeyMap::set QWERTY_MAPPING
 
   # --- Miscellenaous : ---
+  args.state.mode       = 0
   args.state.mode       = Debug::parse_debug_arg($gtk.argv)
-
+  args.state.last_mouse_position  = args.inputs.mouse.point
   args.state.setup_done = true
 end
 


### PR DESCRIPTION
DR hangs when I run this repo in 3.x. It seems to not like using args.state variables before they are instantiated. This will now run in 3.x. The debug mode activated by spacebar still hangs, but that happens in 2.x as well, so I'm guessing that's not related to 3.x.